### PR TITLE
fix: aws provider version constraint

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,14 +45,14 @@ VPC Flow logs.
 | <a name="input_cloudwatch_metric_stream_name"></a> [cloudwatch\_metric\_stream\_name](#input\_cloudwatch\_metric\_stream\_name) | Name of the Cloudwatch Metric Stream. | `string` | `null` | no |
 | <a name="input_firehose_metrics_delivery_stream_name"></a> [firehose\_metrics\_delivery\_stream\_name](#input\_firehose\_metrics\_delivery\_stream\_name) | Name of the Firehose Delivery Stream to use for Cloudwatch Metrics. | `string` | `null` | no |
 | <a name="input_firehose_role_name"></a> [firehose\_role\_name](#input\_firehose\_role\_name) | Name of the Firehose Role to use for Cloudwatch Metrics. | `string` | `null` | no |
-| <a name="input_firehose_role_name_prefix"></a> [firehose\_role\_name\_prefix](#input\_firehose\_role\_name\_prefix) | Whether to use a prefix for the Firehose Role name. | `bool` | `true` | no |
+| <a name="input_firehose_role_name_prefix"></a> [firehose\_role\_name\_prefix](#input\_firehose\_role\_name\_prefix) | Whether to use a prefix for the Firehose Role name. | `bool` | `false` | no |
 | <a name="input_firehose_s3_bucket_name"></a> [firehose\_s3\_bucket\_name](#input\_firehose\_s3\_bucket\_name) | Name of the S3 Bucket to use for Firehose. | `string` | `null` | no |
 | <a name="input_firehose_vpc_delivery_stream_name"></a> [firehose\_vpc\_delivery\_stream\_name](#input\_firehose\_vpc\_delivery\_stream\_name) | Name of the Firehose Delivery Stream to use for VPC Flow Logs. | `string` | `null` | no |
 | <a name="input_flow_logs_vpc_ids"></a> [flow\_logs\_vpc\_ids](#input\_flow\_logs\_vpc\_ids) | List of VPC IDs to enable VPC Flow Logs for. If empty, VPC Flow Logs will not be enabled. | `list(string)` | `[]` | no |
 | <a name="input_ingeration_role_name"></a> [ingeration\_role\_name](#input\_ingeration\_role\_name) | Name of the Integration Role for New Relic. | `string` | `null` | no |
-| <a name="input_integration_role_name_prefix"></a> [integration\_role\_name\_prefix](#input\_integration\_role\_name\_prefix) | Whether to use a prefix for the Integration Role name. | `bool` | `true` | no |
+| <a name="input_integration_role_name_prefix"></a> [integration\_role\_name\_prefix](#input\_integration\_role\_name\_prefix) | Whether to use a prefix for the Integration Role name. | `bool` | `false` | no |
 | <a name="input_metric_stream_role_name"></a> [metric\_stream\_role\_name](#input\_metric\_stream\_role\_name) | Name of the Metric Stream Role to use for Cloudwatch Metrics. | `string` | `null` | no |
-| <a name="input_metric_stream_role_name_prefix"></a> [metric\_stream\_role\_name\_prefix](#input\_metric\_stream\_role\_name\_prefix) | Whether to use a prefix for the Metric Stream Role name. | `bool` | `true` | no |
+| <a name="input_metric_stream_role_name_prefix"></a> [metric\_stream\_role\_name\_prefix](#input\_metric\_stream\_role\_name\_prefix) | Whether to use a prefix for the Metric Stream Role name. | `bool` | `false` | no |
 | <a name="input_name"></a> [name](#input\_name) | Name or prefix for the resources. | `string` | `"new-relic"` | no |
 | <a name="input_new_relic_account_id"></a> [new\_relic\_account\_id](#input\_new\_relic\_account\_id) | Unique identifier for New Relic account. | `string` | n/a | yes |
 | <a name="input_new_relic_cloudwatch_metrics_endpoint"></a> [new\_relic\_cloudwatch\_metrics\_endpoint](#input\_new\_relic\_cloudwatch\_metrics\_endpoint) | New Relic Cloudwatch Endpoint for either EU or US. | `string` | `"https://aws-api.eu01.nr-data.net/cloudwatch-metrics/v1"` | no |
@@ -67,21 +67,21 @@ No outputs.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.36 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.36, < 5.0.0 |
 | <a name="provider_newrelic"></a> [newrelic](#provider\_newrelic) | >= 2.37.0 |
 
 ## Resources
 
-- resource.aws_cloudwatch_metric_stream.main (main.tf#133)
-- resource.aws_flow_log.main (main.tf#282)
-- resource.aws_kinesis_firehose_delivery_stream.cloudwatch_metrics (main.tf#145)
-- resource.aws_kinesis_firehose_delivery_stream.vpc_flow_logs (main.tf#181)
-- resource.aws_s3_bucket.main (main.tf#249)
-- resource.aws_s3_bucket_acl.main (main.tf#255)
-- resource.aws_s3_bucket_public_access_block.main (main.tf#270)
-- resource.aws_s3_bucket_server_side_encryption_configuration.main (main.tf#260)
-- resource.newrelic_api_access_key.main (main.tf#299)
-- resource.newrelic_cloud_aws_link_account.main (main.tf#313)
+- resource.aws_cloudwatch_metric_stream.main (main.tf#137)
+- resource.aws_flow_log.main (main.tf#286)
+- resource.aws_kinesis_firehose_delivery_stream.cloudwatch_metrics (main.tf#149)
+- resource.aws_kinesis_firehose_delivery_stream.vpc_flow_logs (main.tf#185)
+- resource.aws_s3_bucket.main (main.tf#253)
+- resource.aws_s3_bucket_acl.main (main.tf#259)
+- resource.aws_s3_bucket_public_access_block.main (main.tf#274)
+- resource.aws_s3_bucket_server_side_encryption_configuration.main (main.tf#264)
+- resource.newrelic_api_access_key.main (main.tf#303)
+- resource.newrelic_cloud_aws_link_account.main (main.tf#317)
 - data source.aws_caller_identity.current (main.tf#7)
 
 # Examples

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.36"
+      version = ">= 4.36, < 5.0.0"
     }
 
     newrelic = {


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->

## What it solves

s3_configuration block moved with AWS Provider 5.0

## Readiness Checklist

### Author/Contributor
- [ ] If documentation is needed for this change, has that been included in this pull request
- [ ] Pull request title is brief and descriptive (for a changelog entry)

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, or `enhancement`
- [ ] Label as `bump:patch`, `bump:minor`, or `bump:major` if this PR should create a new release
