### PR TITLE
fix: update ECS cluster module to propagate tags to log group

### DIFF
--- a/modules/fargate_php_daemon/main.tf
+++ b/modules/fargate_php_daemon/main.tf
@@ -17,7 +17,7 @@ module "ecs_cluster" {
   count = var.enable_ecs_cluster ? 1 : 0
 
   source  = "geekcell/ecs-cluster/aws"
-  version = ">= 1.0.0, < 2.0.0"
+  version = ">= 2.0.0, < 3.0.0"
 
   name = var.ecs_cluster_name
   tags = var.tags


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->

## What it solves

Update ECS cluster module to propagate tags to log group

## Readiness Checklist

### Author/Contributor
- [ ] If documentation is needed for this change, has that been included in this pull request
- [ ] Pull request title is brief and descriptive (for a changelog entry)

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, or `enhancement`
- [ ] Label as `bump:patch`, `bump:minor`, or `bump:major` if this PR should create a new release
